### PR TITLE
Fix null reference warning

### DIFF
--- a/Dawnsbury.Mods.Remaster.Spellbook/Level2Spells.cs
+++ b/Dawnsbury.Mods.Remaster.Spellbook/Level2Spells.cs
@@ -202,7 +202,7 @@ namespace Dawnsbury.Mods.Remaster.Spellbook
                         caster.AddQEffect(qSustainMultipleEffect);
                     }
 
-                    List<QEffect> list = (List<QEffect>)qSustainMultipleEffect.Tag;
+                    List<QEffect> list = (List<QEffect>)qSustainMultipleEffect.Tag!;
                     list.Add(qEffect);
                 });
             }));


### PR DESCRIPTION
This PR fixes a nullable reference warning to make the mod compile without build warnings. This could not result in an actual exception at runtime, so there is no need to rebuild and reupload the binary to the Steam Workshop, but I would still appreciate if you integrated this PR so that I can build your project without build warnings.